### PR TITLE
Add REST controller layer for recipe operations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-web'
 
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 
 
 	compileOnly 'org.projectlombok:lombok:1.18.46'

--- a/src/main/java/com/maze/recipe/controller/RecipeController.java
+++ b/src/main/java/com/maze/recipe/controller/RecipeController.java
@@ -1,0 +1,49 @@
+package com.maze.recipe.controller;
+
+import com.maze.recipe.dto.request.CreateRecipeDto;
+import com.maze.recipe.dto.response.RecipeResponseDto;
+import com.maze.recipe.service.RecipeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/recipes")
+public class RecipeController {
+    private final RecipeService recipeService;
+
+    public RecipeController(RecipeService recipeService) {
+        this.recipeService = recipeService;
+    }
+
+    @GetMapping
+    public List<RecipeResponseDto> getAllRecipes() {
+        return recipeService.readAllRecipes();
+    }
+
+    @GetMapping("/{id}")
+    public RecipeResponseDto getRecipe(@PathVariable long id) {
+        return recipeService.readRecipe(id);
+    }
+
+    @PostMapping
+    public ResponseEntity<RecipeResponseDto> createRecipe(@RequestBody CreateRecipeDto createRecipeDto) {
+        long id = recipeService.createRecipe(createRecipeDto);
+        RecipeResponseDto created = recipeService.readRecipe(id);
+        return ResponseEntity.created(URI.create("/recipes/" + id)).body(created);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteRecipe(@PathVariable long id) {
+        recipeService.deleteRecipe(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/maze/recipe/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/maze/recipe/exception/GlobalExceptionHandler.java
@@ -1,0 +1,38 @@
+package com.maze.recipe.exception;
+
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.Instant;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RecipeNotFoundException.class)
+    public ResponseEntity<ApiError> handleRecipeNotFound(RecipeNotFoundException ex) {
+        return buildResponse(HttpStatus.NOT_FOUND, ex.getMessage());
+    }
+
+    @ExceptionHandler({InvalidIdException.class, InvalidQuantityException.class})
+    public ResponseEntity<ApiError> handleBadRequest(RuntimeException ex) {
+        return buildResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiError> handleConstraintViolation(ConstraintViolationException ex) {
+        String message = ex.getConstraintViolations().stream()
+                .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
+                .collect(Collectors.joining(", "));
+        return buildResponse(HttpStatus.BAD_REQUEST, message);
+    }
+
+    private ResponseEntity<ApiError> buildResponse(HttpStatus status, String message) {
+        return ResponseEntity.status(status).body(new ApiError(status.value(), message, Instant.now()));
+    }
+
+    public record ApiError(int status, String message, Instant timestamp) {}
+}

--- a/src/test/java/com/maze/recipe/controller/RecipeControllerTest.java
+++ b/src/test/java/com/maze/recipe/controller/RecipeControllerTest.java
@@ -1,0 +1,126 @@
+package com.maze.recipe.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.maze.recipe.dto.request.CreateIngredientDto;
+import com.maze.recipe.dto.request.CreateInstructionDto;
+import com.maze.recipe.dto.request.CreateRecipeDto;
+import com.maze.recipe.dto.response.IngredientResponseDto;
+import com.maze.recipe.dto.response.InstructionResponseDto;
+import com.maze.recipe.dto.response.RecipeResponseDto;
+import com.maze.recipe.exception.InvalidIdException;
+import com.maze.recipe.exception.RecipeNotFoundException;
+import com.maze.recipe.service.RecipeService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RecipeController.class)
+class RecipeControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private RecipeService recipeService;
+
+    @Test
+    void getAllRecipesReturnsOkWithList() throws Exception {
+        when(recipeService.readAllRecipes()).thenReturn(List.of(sampleRecipe()));
+
+        mockMvc.perform(get("/recipes"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].recipeName").value("Sifted Flour Recipe"));
+    }
+
+    @Test
+    void getRecipeByIdReturnsOk() throws Exception {
+        when(recipeService.readRecipe(1L)).thenReturn(sampleRecipe());
+
+        mockMvc.perform(get("/recipes/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.recipeName").value("Sifted Flour Recipe"));
+    }
+
+    @Test
+    void getRecipeByIdReturnsNotFoundWhenMissing() throws Exception {
+        when(recipeService.readRecipe(99L))
+                .thenThrow(new RecipeNotFoundException("Unable to find recipe with id 99"));
+
+        mockMvc.perform(get("/recipes/99"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getRecipeByIdReturnsBadRequestForInvalidId() throws Exception {
+        when(recipeService.readRecipe(-1L))
+                .thenThrow(new InvalidIdException("Provided ID must be greater than 0"));
+
+        mockMvc.perform(get("/recipes/-1"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createRecipeReturnsCreated() throws Exception {
+        CreateRecipeDto createDto = new CreateRecipeDto(
+                "Sifted Flour Recipe",
+                List.of(new CreateIngredientDto("1", "cup", "flour")),
+                List.of(new CreateInstructionDto("Sift it."))
+        );
+
+        when(recipeService.createRecipe(any())).thenReturn(1L);
+        when(recipeService.readRecipe(1L)).thenReturn(sampleRecipe());
+
+        mockMvc.perform(post("/recipes")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(createDto)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/recipes/1"))
+                .andExpect(jsonPath("$.id").value(1));
+    }
+
+    @Test
+    void deleteRecipeReturnsNoContent() throws Exception {
+        when(recipeService.deleteRecipe(1L)).thenReturn(sampleRecipe());
+
+        mockMvc.perform(delete("/recipes/1"))
+                .andExpect(status().isNoContent());
+
+        verify(recipeService).deleteRecipe(1L);
+    }
+
+    @Test
+    void deleteRecipeReturnsNotFoundWhenMissing() throws Exception {
+        when(recipeService.deleteRecipe(99L))
+                .thenThrow(new RecipeNotFoundException("Unable to find recipe with id 99"));
+
+        mockMvc.perform(delete("/recipes/99"))
+                .andExpect(status().isNotFound());
+    }
+
+    private RecipeResponseDto sampleRecipe() {
+        return new RecipeResponseDto(
+                1L,
+                "Sifted Flour Recipe",
+                List.of(new IngredientResponseDto("1", "cup", "flour")),
+                List.of(new InstructionResponseDto("Sift it."))
+        );
+    }
+}


### PR DESCRIPTION
Implements RecipeController with GET /recipes, GET /recipes/{id}, POST /recipes, and DELETE /recipes/{id}, delegating to RecipeService. Adds a GlobalExceptionHandler (@RestControllerAdvice) to translate service-layer exceptions into appropriate HTTP status codes (404 for not found, 400 for invalid id/quantity/validation errors). Also adds the spring-boot-starter-web dependency, which was missing.

Closes #4