### PR TITLE
Add self-healing CI loop for Claude-authored PRs

### DIFF
--- a/.github/workflows/claude-promote-draft.yml
+++ b/.github/workflows/claude-promote-draft.yml
@@ -1,0 +1,45 @@
+name: Claude Promote Draft
+
+# Watches the main CI workflow. When it succeeds on a draft PR carrying the
+# "ai-managed" label (set by claude.yml), flips the PR to ready-for-review
+# so it's just sitting there waiting on approval by the time a human looks.
+
+on:
+  workflow_run:
+    workflows: ["Java CI with Gradle"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  promote:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark ai-managed draft PRs as ready for review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          PR_JSON=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" --state open --json number,isDraft,labels --jq '.[0] // empty')
+
+          if [ -z "$PR_JSON" ]; then
+            echo "No open PR for branch $BRANCH; skipping."
+            exit 0
+          fi
+
+          IS_DRAFT=$(echo "$PR_JSON" | jq -r '.isDraft')
+          MANAGED=$(echo "$PR_JSON" | jq -r '.labels | any(.name == "ai-managed")')
+
+          if [ "$IS_DRAFT" != "true" ] || [ "$MANAGED" != "true" ]; then
+            echo "Not an ai-managed draft PR; skipping."
+            exit 0
+          fi
+
+          NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          gh pr ready "$NUMBER" --repo "$GITHUB_REPOSITORY"
+          gh pr comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body "CI passed -- marking ready for review."

--- a/.github/workflows/claude-self-heal.yml
+++ b/.github/workflows/claude-self-heal.yml
@@ -1,0 +1,82 @@
+name: Claude Self-Heal
+
+# Watches the main CI workflow. If it fails on a PR that Claude opened (the
+# "ai-managed" label, set by claude.yml), ask Claude to look at the failure
+# and push a fix -- capped at 3 attempts so a persistently broken PR gets
+# handed back to a human instead of looping forever.
+
+on:
+  workflow_run:
+    workflows: ["Java CI with Gradle"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+  id-token: write
+
+jobs:
+  self-heal:
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gather PR context and check retry budget
+        id: ctx
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          PR_JSON=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" --state open --json number,headRefName,labels --jq '.[0] // empty')
+
+          if [ -z "$PR_JSON" ]; then
+            echo "No open PR for branch $BRANCH; skipping."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          MANAGED=$(echo "$PR_JSON" | jq -r '.labels | any(.name == "ai-managed")')
+          if [ "$MANAGED" != "true" ]; then
+            echo "PR is not ai-managed; skipping."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+          ATTEMPTS=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow "claude-self-heal.yml" --branch "$BRANCH" --json status --jq '[.[] | select(.status == "completed")] | length')
+          echo "Prior self-heal attempts on this branch: $ATTEMPTS"
+
+          if [ "$ATTEMPTS" -ge 3 ]; then
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            gh pr edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "needs-human"
+            gh pr comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body "Self-heal gave up after 3 attempts -- CI is still failing. Needs a human look."
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout PR branch
+        if: steps.ctx.outputs.proceed == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.ctx.outputs.branch }}
+          fetch-depth: 1
+
+      - name: Ask Claude to fix the failing build
+        if: steps.ctx.outputs.proceed == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          prompt: |
+            CI ("Java CI with Gradle") just failed on PR #${{ steps.ctx.outputs.number }},
+            branch ${{ steps.ctx.outputs.branch }}, run ${{ github.event.workflow_run.html_url }}.
+            Run `gh run view ${{ github.event.workflow_run.id }} --log-failed` to see what broke,
+            fix the underlying issue, and push the fix to this same branch (do not open a new PR).
+            Leave a short comment on the PR explaining what broke and what you changed.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write # Required for Claude to create branches and push commits
+      pull-requests: write # Required for Claude to open PRs and add labels
+      issues: write # Required for Claude to comment back on the triggering issue
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -43,8 +43,9 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr *)'
+          # Standing instructions appended to every run, on top of whatever the triggering
+          # comment/issue asked for. These make the self-heal and auto-promote workflows work:
+          # they key off the "ai-managed" label and the draft state set here.
+          claude_args: |
+            --append-system-prompt "When implementing a ticket end-to-end: create a new branch, implement the change, and run the project's build/tests locally until they pass. Then open the pull request as a draft (gh pr create --draft) with a description summarizing what the ticket asked for and what you changed, and add the 'ai-managed' label to it (gh pr edit --add-label ai-managed). Do not mark the PR ready for review yourself -- a separate automated workflow does that once CI passes."
 


### PR DESCRIPTION
## Summary
- `claude.yml`: standing instructions (via `--append-system-prompt`) so Claude always opens its PRs as drafts labeled `ai-managed`, with local tests run first; bumped permissions to `contents: write` / `pull-requests: write` / `issues: write` so it can actually create branches, push, open PRs, and label them.
- `claude-self-heal.yml` (new): watches the `Java CI with Gradle` workflow; on failure for an `ai-managed` PR, re-invokes Claude with the failure logs to push a fix. Capped at 3 attempts per branch, then labels the PR `needs-human` and bails.
- `claude-promote-draft.yml` (new): on CI success for an `ai-managed` draft PR, runs `gh pr ready` to flip it out of draft.

Together these let a ticket go: `@claude` mention → implementation → draft PR → self-healing on red CI → auto-promoted to ready-for-review, with no manual babysitting in between.

Note: the two new `workflow_run`-triggered workflows only activate once this merges to `main` — they won't run within this PR itself.

## Test plan
- [ ] After merge, tag `@claude` on a test issue and confirm it opens a draft PR labeled `ai-managed`
- [ ] Intentionally break the build on that PR and confirm `claude-self-heal.yml` fires and pushes a fix
- [ ] Confirm `claude-promote-draft.yml` flips the PR to ready-for-review once CI is green
- [ ] Confirm the 3-attempt cap and `needs-human` label work if CI keeps failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)